### PR TITLE
fix <link> pattern: support href attribute on different line

### DIFF
--- a/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
+++ b/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
@@ -34,7 +34,7 @@ public class FingerprintMojo extends AbstractMojo {
 	/*
 	 * All resources should have absolute paths: Valid: <img src="/img/test.png"> . Invalid: <img src="test.png"> All resources should point to existing files without any pre-processing: Valid: <img src="/img/test.png"> . Invalid: <img src="<c:if test="${var}">/img/test.png</c:if>"
 	 */
-	public static final Pattern LINK_PATTERN = Pattern.compile("(<link.*?href=\")(.*?)(\".*?>)");
+	public static final Pattern LINK_PATTERN = Pattern.compile("(<link[^>]+href=\")(.*?)(\"[^>]*>)");
 	public static final Pattern SCRIPT_PATTERN = Pattern.compile("(\")([^\\s]*?\\.js)(\")");
 	public static final Pattern IMG_PATTERN = Pattern.compile("(<img.*?src=\")([^\\}\\{]*?)(\".*?>)");
 	public static final Pattern CSS_IMG_PATTERN = Pattern.compile("(url\\([\",'])(.*?)([\",']\\))");

--- a/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
+++ b/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
@@ -19,6 +19,10 @@ public class FingerprintMojoTest {
 		Matcher linkMatcher = linkPattern.matcher(linkUrl);
 		assertTrue(linkMatcher.find());
 
+		String multilineLinkUrl = "<link\n    rel=\"stylesheet\"\n    href=\"${pageContext.request.contextPath}/resources/css/style.css\" />";
+		Matcher multilineLinkMatcher = linkPattern.matcher(multilineLinkUrl);
+		assertTrue(multilineLinkMatcher.find());
+
 		Pattern scriptPattern = FingerprintMojo.SCRIPT_PATTERN;
 		String scriptUrl = "<script src=\"${pageContext.request.contextPath}/resources/js/vendor/zepto.js\">";
 		Matcher scriptMatcher = scriptPattern.matcher(scriptUrl);


### PR DESCRIPTION
The plugin did not touch stylesheet references when the HTML looked like this:
```
        <link
            rel="stylesheet"
            href="/stylesheet.css">
```

This PR fixes that.