### PR TITLE
Fix the patterns for <img> and URLs in JSTL/CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ This plugin performs several optimizations:
 During this process plugin calculates file checksum and prepends it to the file name. All links to this filename will be changed to the fingerprinted version. Original file will be deleted. Fingerprinting used to improve web resource caching. If file checksum is not changed, then the name will be the same and it is safe to add max expires header. Once file contents are changed, checksum will be changed as well. This plugin filters out (recursivly) source directory, detects any resources using the patterns below and copy result (if needed) to the target directory.
 
 The following patterns are used to detect resources eligible for fingerprinting:
-  * `<link.*?href="(.*?)".*?>`
-  * `"([^\\s]*?\\.js)"`
-  * `<img.*?src="(.*?)".*?>`
-  * `url\("(.*?)"\)`
-  * `(<c:url.*?value=\")(/{1}.*?)(\".*?>)`
+  * `<link[^>]+href="(.*?)"[^>]*>`
+  * `"([^\s]*?\.js)"`
+  * `<img[^>]+src="([^\}\{]*?)"[^>]+>`
+  * `url\(\s*["']?(.*?)["']?\s*\)`
+  * `<c:url[^>]+value="(/{1}.*?)"[^>]+>`
 
 After fingerprinting it is safe to add max expires header. 
 

--- a/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
+++ b/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
@@ -36,7 +36,7 @@ public class FingerprintMojo extends AbstractMojo {
 	 */
 	public static final Pattern LINK_PATTERN = Pattern.compile("(<link[^>]+href=\")(.*?)(\"[^>]*>)");
 	public static final Pattern SCRIPT_PATTERN = Pattern.compile("(\")([^\\s]*?\\.js)(\")");
-	public static final Pattern IMG_PATTERN = Pattern.compile("(<img.*?src=\")([^\\}\\{]*?)(\".*?>)");
+	public static final Pattern IMG_PATTERN = Pattern.compile("(<img[^>]+src=\")([^\\}\\{]*?)(\"[^>]+>)");
 	public static final Pattern CSS_IMG_PATTERN = Pattern.compile("(url\\([\",'])(.*?)([\",']\\))");
 	public static final Pattern JSTL_URL_PATTERN = Pattern.compile("(<c:url.*?value=\")(/{1}.*?)(\".*?>)");
 	public static final Pattern DOLLAR_SIGN = Pattern.compile("\\$");

--- a/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
+++ b/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
@@ -20,7 +20,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;

--- a/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
+++ b/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
@@ -38,7 +38,7 @@ public class FingerprintMojo extends AbstractMojo {
 	public static final Pattern SCRIPT_PATTERN = Pattern.compile("(\")([^\\s]*?\\.js)(\")");
 	public static final Pattern IMG_PATTERN = Pattern.compile("(<img[^>]+src=\")([^\\}\\{]*?)(\"[^>]+>)");
 	public static final Pattern CSS_URL_PATTERN = Pattern.compile("(url\\(\\s*[\"']?)(.*?)([\"']?\\s*\\))");
-	public static final Pattern JSTL_URL_PATTERN = Pattern.compile("(<c:url.*?value=\")(/{1}.*?)(\".*?>)");
+	public static final Pattern JSTL_URL_PATTERN = Pattern.compile("(<c:url[^>]+value=\")(/{1}.*?)(\"[^>]+>)");
 	public static final Pattern DOLLAR_SIGN = Pattern.compile("\\$");
 
 	/**

--- a/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
+++ b/src/main/java/com/st/maven/fingerprint/FingerprintMojo.java
@@ -37,7 +37,7 @@ public class FingerprintMojo extends AbstractMojo {
 	public static final Pattern LINK_PATTERN = Pattern.compile("(<link[^>]+href=\")(.*?)(\"[^>]*>)");
 	public static final Pattern SCRIPT_PATTERN = Pattern.compile("(\")([^\\s]*?\\.js)(\")");
 	public static final Pattern IMG_PATTERN = Pattern.compile("(<img[^>]+src=\")([^\\}\\{]*?)(\"[^>]+>)");
-	public static final Pattern CSS_IMG_PATTERN = Pattern.compile("(url\\([\",'])(.*?)([\",']\\))");
+	public static final Pattern CSS_URL_PATTERN = Pattern.compile("(url\\(\\s*[\"']?)(.*?)([\"']?\\s*\\))");
 	public static final Pattern JSTL_URL_PATTERN = Pattern.compile("(<c:url.*?value=\")(/{1}.*?)(\".*?>)");
 	public static final Pattern DOLLAR_SIGN = Pattern.compile("\\$");
 
@@ -140,7 +140,7 @@ public class FingerprintMojo extends AbstractMojo {
 		outputFileData = processPattern(LINK_PATTERN, outputFileData.toString(), sourceFile.getAbsolutePath());
 		outputFileData = processPattern(SCRIPT_PATTERN, outputFileData.toString(), sourceFile.getAbsolutePath());
 		outputFileData = processPattern(IMG_PATTERN, outputFileData.toString(), sourceFile.getAbsolutePath());
-		outputFileData = processPattern(CSS_IMG_PATTERN, outputFileData.toString(), sourceFile.getAbsolutePath());
+		outputFileData = processPattern(CSS_URL_PATTERN, outputFileData.toString(), sourceFile.getAbsolutePath());
 		outputFileData = processPattern(JSTL_URL_PATTERN, outputFileData.toString(), sourceFile.getAbsolutePath());
 		String processedData = null;
 		if (htmlExtensions != null && !htmlExtensions.isEmpty()) {

--- a/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
+++ b/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
@@ -88,6 +88,12 @@ public class FingerprintMojoTest {
 		String jstlUrl3 = "<c:url value=\"http://www.fedex.com/Tracking?ascend_header=1&amp;clienttype=dotcom&amp;cntry_code=us&amp;language=english&amp;tracknumbers=${shipment.trackingNumber}\" var=\"fedexUrl\"/>";
 		Matcher jstlUrlMatcher3 = jstlUrlPattern.matcher(jstlUrl3);
 		assertFalse(jstlUrlMatcher3.find());
+
+		// Multiline JSTL url, absolute
+		String jstlUrl4 = "<c:url\n    value=\"/resources/images/favicon.ico\"\n    var=\"faviconUrl\"\n    />";
+		Matcher jstlUrlMatcher4 = jstlUrlPattern.matcher(jstlUrl4);
+		assertTrue(jstlUrlMatcher4.find());
+
 	}
 
 	@Test

--- a/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
+++ b/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
@@ -29,9 +29,13 @@ public class FingerprintMojoTest {
 		assertTrue(scriptMatcher.find());
 
 		Pattern imgPattern = FingerprintMojo.IMG_PATTERN;
-		String imageUrl = "<img src=\"${pageContext.request.contextPath}/images/favicon-whatever.ico\" />";
-		Matcher imgMatcher = imgPattern.matcher(imageUrl);
-		assertFalse(imgMatcher.find());
+		String imageUrl1 = "<img src=\"${pageContext.request.contextPath}/images/favicon-whatever.ico\" />";
+		Matcher imgMatcher1 = imgPattern.matcher(imageUrl1);
+		assertFalse(imgMatcher1.find());
+
+		String imageUrl2 = "<img src=\"/images/photo.jpg\" />";
+		Matcher imgMatcher2 = imgPattern.matcher(imageUrl2);
+		assertTrue(imgMatcher2.find());
 
 		// Tests for the CSS image references
 		Pattern cssPattern = FingerprintMojo.CSS_IMG_PATTERN;

--- a/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
+++ b/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
@@ -42,26 +42,36 @@ public class FingerprintMojoTest {
 		assertTrue(imgMatcher3.find());
 
 		// Tests for the CSS image references
-		Pattern cssPattern = FingerprintMojo.CSS_IMG_PATTERN;
-		// Double quotes url, absolute location
-		String cssUrl1 = "url(\"/images/navigation-s66728e073e.png\")";
+		Pattern cssPattern = FingerprintMojo.CSS_URL_PATTERN;
+		// Double-quoted url, absolute location
+		String cssUrl1 = "url( \"/images/navigation-s66728e073e.png\" )";
 		Matcher cssMatcher1 = cssPattern.matcher(cssUrl1);
 		assertTrue(cssMatcher1.find());
 
-		// Single quotes url, absolute location
-		String cssUrl2 = "url('/images/navigation-s66728e073e.png')";
+		// Single-quoted url, absolute location
+		String cssUrl2 = "url( '/images/navigation-s66728e073e.png' )";
 		Matcher cssMatcher2 = cssPattern.matcher(cssUrl2);
 		assertTrue(cssMatcher2.find());
 
-		// Double quotes url, relative location
-		String cssUrl3 = "url(\"../images/navigation-s66728e073e.png\")";
+		// Unquoted url, absolute location
+		String cssUrl3 = "url( /images/navigation-s66728e073e.png )";
 		Matcher cssMatcher3 = cssPattern.matcher(cssUrl3);
 		assertTrue(cssMatcher3.find());
 
-		// Double quotes url, relative location
-		String cssUrl4 = "url('../images/navigation-s66728e073e.png')";
+		// Double-quoted url, relative location
+		String cssUrl4 = "url( \"../images/navigation-s66728e073e.png\" )";
 		Matcher cssMatcher4 = cssPattern.matcher(cssUrl4);
 		assertTrue(cssMatcher4.find());
+
+		// Single-quoted url, relative location
+		String cssUrl5 = "url( '../images/navigation-s66728e073e.png' )";
+		Matcher cssMatcher5 = cssPattern.matcher(cssUrl5);
+		assertTrue(cssMatcher5.find());
+
+		// Unquoted url, relative location
+		String cssUrl6 = "url( ../images/navigation-s66728e073e.png )";
+		Matcher cssMatcher6 = cssPattern.matcher(cssUrl6);
+		assertTrue(cssMatcher6.find());
 
 		// JSTL url, absolute
 		Pattern jstlUrlPattern = FingerprintMojo.JSTL_URL_PATTERN;

--- a/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
+++ b/src/test/java/com/st/maven/fingerprint/FingerprintMojoTest.java
@@ -37,6 +37,10 @@ public class FingerprintMojoTest {
 		Matcher imgMatcher2 = imgPattern.matcher(imageUrl2);
 		assertTrue(imgMatcher2.find());
 
+		String imageUrl3 = "<img\n    src=\"/images/photo.jpg\"\n    />";
+		Matcher imgMatcher3 = imgPattern.matcher(imageUrl3);
+		assertTrue(imgMatcher3.find());
+
 		// Tests for the CSS image references
 		Pattern cssPattern = FingerprintMojo.CSS_IMG_PATTERN;
 		// Double quotes url, absolute location


### PR DESCRIPTION
Here are several fixes rolled into one PR. Please edit the branch as needed, or tell me if I should change anything!

- Multiline `<img>` tags were not recognized (similar to #8)
- The CSS `url()` pattern had several bugs:
  - The regex syntax for "single or double quote" was wrong: `[",']` (in a Java string: `"[\",']"`) would have matched not only double and single quotes, but also commas.
  - As explained [here](https://stackoverflow.com/a/2168861/7641), the CSS spec says quotes inside `url()` are optional, but the plugin did not recognize unquoted values.
  - Similarly, the plugin did not recognize URLs with whitespace between the parentheses and the actual URL (with or without quotes), which is also allowed according to the CSS spec (see link in previous point).
- Multiline `<c:url>` tags were not recognized.

Furthermore, I updated the list of patterns in the README:
- Even before these changes, they did not match the patterns in the sources exactly.
- The JSTL URL pattern in the README had all three groups. As they are a mere implementation detail, I changed that to only include the middle group (catching the file name), consistently with the others.
- The JS pattern used escaping rules like in a Java string literal (`\\s`), but the CSS URL pattern did not (`"` instead of `\"`). I made them consistent by using the pure regular expression syntax (without the escaping required in Java string literals). This way, users can copy-paste them into e.g. the "Find" dialog of their editor.